### PR TITLE
docs: Update README with packaged executable instructions\n\n- Added …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+Folder Color Changer.spec
+Icon
+build/
+dist/
+fileicon.swift
+icons/*.icns

--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ This is the simplest and most intuitive way to use the application.
 ### 2. Command Line Interface (CLI)
 ### 2. 命令列介面 (CLI)
 
+### 3. Packaged Executable
+### 3. 打包執行檔
+
+For a standalone application that doesn't require Python or virtual environment setup, you can use the packaged executable.
+對於不需要 Python 或虛擬環境設定的獨立應用程式，您可以使用打包好的執行檔。
+
+1.  **Locate the Executable**:
+    The executable can be found in the `dist` directory after the application has been built. The path will typically be `dist/Folder Color Changer/Folder Color Changer`.
+    **找到執行檔**：
+    執行檔在應用程式建置後會位於 `dist` 目錄中。路徑通常是 `dist/Folder Color Changer/Folder Color Changer`。
+
+2.  **Run the Application**:
+    You can run the application directly by double-clicking it in Finder, or by executing it from the terminal:
+    **執行應用程式**：
+    您可以直接在 Finder 中雙擊執行應用程式，或從終端機執行：
+    ```bash
+    /Users/dino/Desktop/folder_color_changer/dist/Folder\ Color\ Changer/Folder\ Color\ Changer
+    ```
+    This will launch the GUI application.
+    這將會啟動 GUI 應用程式。
+
+---
+
 For users who need automation or prefer command-line operations, the `color-folder.sh` script can be used.
 對於需要自動化或偏好命令列操作的使用者，可以使用 `color-folder.sh` 腳本。
 

--- a/color-folder.sh
+++ b/color-folder.sh
@@ -27,50 +27,6 @@ ICON_DIR="$SCRIPT_DIR/icons"
 
 FILEICON_TOOL="$SCRIPT_DIR/fileicon"
 
-# 如果 fileicon 工具不存在，就地編譯它
-if [ ! -f "$FILEICON_TOOL" ]; then
-    echo "正在首次設定，編譯 fileicon 工具..."
-    SWIFT_CODE=$(cat <<EOF
-import Foundation
-import AppKit
-
-// 移除頂層的參數數量檢查，改為依賴 switch 語句內部的精確檢查
-
-let command = CommandLine.arguments[1]
-let path = CommandLine.arguments[2]
-
-switch command {
-case "set":
-    if CommandLine.arguments.count != 4 {
-        print("Usage: fileicon set <path> <icon_path>")
-        exit(1)
-    }
-    let iconPath = CommandLine.arguments[3]
-    guard let icon = NSImage(contentsOfFile: iconPath) else {
-        print("Error: Could not load icon from \(iconPath)")
-        exit(1)
-    }
-    NSWorkspace.shared.setIcon(icon, forFile: path, options: [])
-case "rm":
-    if CommandLine.arguments.count != 3 {
-        print("Usage: fileicon rm <path>")
-        exit(1)
-    }
-    NSWorkspace.shared.setIcon(nil, forFile: path, options: [])
-default:
-    print("Unknown command \(command)")
-    exit(1)
-}
-EOF
-)
-    # 使用 swiftc 編譯程式碼
-    echo "$SWIFT_CODE" | swiftc -o "$FILEICON_TOOL" -
-    if [ $? -ne 0 ]; then
-        echo "錯誤: 編譯 fileicon 工具失敗。請確認您已安裝 Xcode Command Line Tools。"
-        exit 1
-    fi
-    echo "fileicon 工具編譯完成。"
-fi
 
 # --- 主要邏輯 --- #
 


### PR DESCRIPTION
…a new section in README.md to guide users on how to use the packaged executable.\n- Removed the in-script compilation logic for 'fileicon' from color-folder.sh as it's no longer needed with the packaged executable.\n- Updated .gitignore to exclude build artifacts and system files.